### PR TITLE
Hide white header on mobile version

### DIFF
--- a/index.html
+++ b/index.html
@@ -2600,6 +2600,14 @@
             /* Buttons on tablet should not be full-width by default */
             .btn-primary { width: auto; min-height: 48px; padding-left: 1.25rem; padding-right: 1.25rem; }
         }
+
+        /* Mobile override: hide header completely */
+        @media (max-width: 768px) {
+            header { display: none !important; }
+            html { scroll-padding-top: 0 !important; }
+            section:first-of-type { padding-top: 0 !important; }
+            #mobileMenu { padding-top: 0 !important; }
+        }
     </style>
 
     <script>


### PR DESCRIPTION
Hide the header on mobile devices to remove the blank white bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-5baf0904-2b04-40f1-814f-29da7fb7b5b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5baf0904-2b04-40f1-814f-29da7fb7b5b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

