### PR TITLE
Fix footer spacing for proper page bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -4335,6 +4335,14 @@
         }
         /* Offset native anchor jumps by header height as fallback */
         section[id] { scroll-margin-top: calc(var(--header-offset, 3.5rem) + 8px); }
+
+        /* Sticky footer layout to remove extra space below footer */
+        html, body { height: 100%; min-height: 100%; }
+        body { display: flex; flex-direction: column; margin: 0; padding-bottom: 0; }
+        footer { margin-top: auto !important; }
+
+        /* Hide trailing CTA bar to ensure footer is last element */
+        .mobile-cta-bar { display: none !important; }
     </style>
     <script>
         // Global smooth scrolling with header offset and section highlight


### PR DESCRIPTION
Implement sticky footer and remove trailing whitespace by hiding a mobile CTA bar and adjusting body layout.

This ensures the website ends precisely at the footer, which now correctly sticks to the bottom of the viewport on short pages and moves naturally with content on longer pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1d61002-a898-4498-8623-1bce446ba836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1d61002-a898-4498-8623-1bce446ba836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

