### PR TITLE
Integrate markdown news posts into website

### DIFF
--- a/index.html
+++ b/index.html
@@ -3466,6 +3466,7 @@
                     <a href="#about" class="nav-link text-gray-700 hover:text-primary font-medium">O nas</a>
                     <a href="#services" class="nav-link text-gray-700 hover:text-primary font-medium">Storitve</a>
                     <a href="#contact" class="nav-link text-gray-700 hover:text-primary font-medium">Kontakt</a>
+                    <a href="/news/" class="nav-link text-gray-700 hover:text-primary font-medium">News</a>
                     <a href="#join" class="btn-primary text-white font-bold py-2 px-6 rounded-full ml-4 pulse">Pridruži se <i class="fas fa-arrow-right ml-2"></i></a>
                 </nav>
                 
@@ -3490,6 +3491,7 @@
                 <a href="#about" class="mobile-nav-item text-lg font-medium text-gray-800 hover:text-primary">O nas</a>
                 <a href="#services" class="mobile-nav-item text-lg font-medium text-gray-800 hover:text-primary">Storitve</a>
                 <a href="#contact" class="mobile-nav-item text-lg font-medium text-gray-800 hover:text-primary">Kontakt</a>
+                <a href="/news/" class="mobile-nav-item text-lg font-medium text-gray-800 hover:text-primary">News</a>
                 <a href="#join" class="mobile-nav-item btn-primary text-white font-bold py-3 px-6 rounded-full text-center mt-4">Pridruži se <i class="fas fa-arrow-right ml-2"></i></a>
             </nav>
         </div>

--- a/news/index.html
+++ b/news/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="sl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>News – Sonce Slovenije</title>
+    <meta name="description" content="Novice in objave Sindikat Sonce Koper.">
+    <link rel="preconnect" href="https://cdn.tailwindcss.com" crossorigin>
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="dns-prefetch" href="//cdn.tailwindcss.com">
+    <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/news/news.css">
+</head>
+<body class="bg-gray-50">
+    <header class="bg-white shadow-sm">
+        <div class="container mx-auto px-4">
+            <div class="flex justify-between items-center py-4">
+                <a href="/" class="flex items-center gap-3">
+                    <img src="/images/soncelogo.jpg" alt="Sonce Slovenije" class="h-10" loading="eager" decoding="async">
+                    <span class="text-gray-900 font-semibold">Sonce Slovenije</span>
+                </a>
+                <nav class="hidden md:flex items-center gap-6">
+                    <a href="/" class="text-gray-700 hover:text-primary">Domov</a>
+                    <a href="/news/" class="text-primary font-semibold">News</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 py-10 max-w-6xl">
+        <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-8">News</h1>
+        <div id="news-list" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"></div>
+        <p id="empty-state" class="hidden text-gray-600">Ni objav za prikaz.</p>
+    </main>
+
+    <footer class="mt-16 py-8 text-center text-gray-500 text-sm">
+        <p>&copy; <span id="year"></span> Sonce Slovenije</p>
+    </footer>
+
+    <script>
+        (function(){
+            function escapeHtml(str){
+                const p = document.createElement('p');
+                p.appendChild(document.createTextNode(str || ''));
+                return p.innerHTML;
+            }
+            function formatDate(iso){
+                try { return new Date(iso).toLocaleDateString('sl-SI', { year:'numeric', month:'long', day:'numeric' }); } catch(e){ return iso || ''; }
+            }
+            function render(posts){
+                const list = document.getElementById('news-list');
+                const empty = document.getElementById('empty-state');
+                if (!posts || posts.length === 0){ empty.classList.remove('hidden'); return; }
+                const frag = document.createDocumentFragment();
+                posts.forEach(p => {
+                    const a = document.createElement('a');
+                    a.href = `/news/post.html?slug=${encodeURIComponent(p.slug)}`;
+                    a.className = 'news-card block rounded-2xl overflow-hidden bg-white border border-gray-100 shadow-sm hover:shadow-md transition-shadow';
+                    a.innerHTML = `
+                        <div class="aspect-[16/9] bg-gray-100 overflow-hidden">
+                            <img src="${escapeHtml(p.hero || '')}" alt="${escapeHtml(p.title || '')}" class="w-full h-full object-cover" loading="lazy" decoding="async" onerror="this.style.display='none'">
+                        </div>
+                        <div class="p-5">
+                            <div class="text-sm text-gray-500">${formatDate(p.date)}${p.author ? ` • ${escapeHtml(p.author)}` : ''}</div>
+                            <h2 class="mt-2 text-xl font-semibold text-gray-900">${escapeHtml(p.title)}</h2>
+                            <p class="mt-2 text-gray-700 line-clamp-3">${escapeHtml(p.excerpt || '')}</p>
+                            <span class="mt-4 inline-flex items-center gap-2 text-primary font-medium">Preberi več <i class="fa-solid fa-arrow-right"></i></span>
+                        </div>`;
+                    frag.appendChild(a);
+                });
+                list.appendChild(frag);
+            }
+            async function load(){
+                try {
+                    const res = await fetch('/content/news/index.json', { cache: 'no-cache' });
+                    if (!res.ok) throw new Error('Failed to load index.json');
+                    const data = await res.json();
+                    const posts = Array.isArray(data) ? data : Array.isArray(data.posts) ? data.posts : [];
+                    posts.sort((a,b)=> (b.date||'').localeCompare(a.date||''));
+                    render(posts);
+                } catch (e) {
+                    document.getElementById('empty-state').textContent = 'Napaka pri nalaganju novic.';
+                    document.getElementById('empty-state').classList.remove('hidden');
+                }
+            }
+            document.getElementById('year').textContent = new Date().getFullYear();
+            load();
+        })();
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" defer></script>
+</body>
+</html>

--- a/news/news.css
+++ b/news/news.css
@@ -1,0 +1,13 @@
+/* News shared styles */
+.container { max-width: 1200px; }
+.news-card h2 { line-height: 1.3; }
+.line-clamp-3 { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+
+/* Post content */
+.news-article h1 { font-size: 2rem; line-height: 1.2; font-weight: 700; }
+.news-article h2 { font-size: 1.5rem; margin-top: 1.5rem; font-weight: 600; }
+.news-article p { margin-top: 1rem; color: #374151; }
+.news-article img { border-radius: 0.75rem; }
+.news-article blockquote { border-left: 4px solid #FF5F15; padding-left: 1rem; color: #4B5563; font-style: italic; }
+.news-article pre { background: #0f172a; color: #e5e7eb; padding: 1rem; border-radius: 0.75rem; overflow: auto; }
+.news-article code { background: #f3f4f6; padding: 0.1rem 0.25rem; border-radius: 0.375rem; }


### PR DESCRIPTION
Introduce a 'News' section with a listing page and header navigation to support Markdown news posts.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e3838e5-42b1-474b-a240-74e135211e4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3e3838e5-42b1-474b-a240-74e135211e4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

