### PR TITLE
Ensure news page compatibility with generated files

### DIFF
--- a/news/index.html
+++ b/news/index.html
@@ -269,7 +269,7 @@
                 
                 pagePosts.forEach(p => {
                     const a = document.createElement('a');
-                    a.href = `/news/post.html?slug=${encodeURIComponent(p.slug)}`;
+                    a.href = (p.path || p.link) ? `/news/post.html?path=${encodeURIComponent(p.path || p.link)}` : `/news/post.html?slug=${encodeURIComponent(p.slug)}`;
                     a.className = 'news-card block rounded-2xl overflow-hidden bg-white border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 hover:-translate-y-1';
                     a.setAttribute('aria-label', `${p.title || 'Objava'} – ${formatDate(p.date)}${p.author ? `, ${p.author}` : ''}`);
                     
@@ -281,7 +281,7 @@
                 a.innerHTML = `
                     <div class="media aspect-[16/9] ${hasImage ? 'bg-gray-100' : 'bg-gradient-to-br from-orange-50 to-orange-100'} overflow-hidden">
                         ${hasImage ? 
-                            `<img src="${escapeHtml(imageSrc)}" alt="${escapeHtml(p.title || '')}" class="w-full h-full object-cover" loading="lazy" decoding="async" onerror="this.style.display='none'; this.parentElement.classList.add('bg-gradient-to-br', 'from-orange-50', 'to-orange-100');">` :
+                            `<img src="${escapeHtml(imageSrc)}" alt="${escapeHtml(p.imageAlt || p.title || '')}" class="w-full h-full object-cover" loading="lazy" decoding="async" onerror="this.style.display='none'; this.parentElement.classList.add('bg-gradient-to-br', 'from-orange-50', 'to-orange-100');">` :
                                 `<div class="w-full h-full flex items-center justify-center">
                                     <svg class="w-16 h-16 text-orange-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 01-2-2V9a2 2 0 012-2h2a2 2 0 012 2v10a2 2 0 01-2 2z"></path>
@@ -439,7 +439,7 @@
                     const list = state.filteredPosts.slice(0, 10).map((p, idx) => ({
                         '@type': 'ListItem',
                         position: idx + 1,
-                        url: BASE_URL + '/news/post.html?slug=' + encodeURIComponent(p.slug),
+                        url: BASE_URL + '/news/post.html?' + ((p.path || p.link) ? ('path=' + encodeURIComponent(p.path || p.link)) : ('slug=' + encodeURIComponent(p.slug))),
                         name: p.title || ''
                     }));
                     const json = {

--- a/news/post.html
+++ b/news/post.html
@@ -297,7 +297,7 @@
                     if (idx > 0){
                         const prev = sorted[idx - 1];
                         const a = document.createElement('a');
-                        a.href = `/news/post.html?slug=${encodeURIComponent(prev.slug)}`;
+                        a.href = (prev.path || prev.link) ? `/news/post.html?path=${encodeURIComponent(prev.path || prev.link)}` : `/news/post.html?slug=${encodeURIComponent(prev.slug)}`;
                         a.className = 'block p-4 border border-gray-200 rounded-xl hover:border-orange-300 hover:shadow-sm';
                         a.innerHTML = `<div class="text-sm text-gray-500 mb-1">← Prejšnja</div><div class="font-medium text-gray-900 line-clamp-2">${escapeHtml(prev.title||'')}</div>`;
                         els.prevNext.appendChild(a);
@@ -306,7 +306,7 @@
                     if (idx < sorted.length - 1){
                         const next = sorted[idx + 1];
                         const a = document.createElement('a');
-                        a.href = `/news/post.html?slug=${encodeURIComponent(next.slug)}`;
+                        a.href = (next.path || next.link) ? `/news/post.html?path=${encodeURIComponent(next.path || next.link)}` : `/news/post.html?slug=${encodeURIComponent(next.slug)}`;
                         a.className = 'block p-4 border border-gray-200 rounded-xl hover:border-orange-300 hover:shadow-sm md:ml-auto';
                         a.innerHTML = `<div class="text-sm text-gray-500 mb-1">Naslednja →</div><div class="font-medium text-gray-900 line-clamp-2">${escapeHtml(next.title||'')}</div>`;
                         els.prevNext.appendChild(a);
@@ -328,7 +328,7 @@
                     els.relatedList.innerHTML = '';
                     list.forEach(p => {
                         const a = document.createElement('a');
-                        a.href = `/news/post.html?slug=${encodeURIComponent(p.slug)}`;
+                        a.href = (p.path || p.link) ? `/news/post.html?path=${encodeURIComponent(p.path || p.link)}` : `/news/post.html?slug=${encodeURIComponent(p.slug)}`;
                         a.className = 'news-card block rounded-xl overflow-hidden bg-white border border-gray-200 hover:shadow-md';
                         const hasImage = (p.hero && p.hero.trim());
                         a.innerHTML = `
@@ -378,8 +378,9 @@
             }
 
             async function load(){
+                const pathParam = getParam('path');
                 const slug = getParam('slug');
-                if (!slug){ 
+                if (!pathParam && !slug){ 
                     showEmpty('Manjka parameter objave.'); 
                     return; 
                 }
@@ -389,7 +390,13 @@
                     const res = await fetch('/content/news/index.json', { cache: 'no-cache' });
                     const data = await res.json().catch(()=>[]);
                     const posts = Array.isArray(data) ? data : Array.isArray(data.posts) ? data.posts : [];
-                    const post = posts.find(p => String(p.slug) === slug);
+                    let post = null;
+                    if (pathParam){
+                        post = posts.find(p => String(p.path || p.link) === String(pathParam));
+                    }
+                    if (!post && slug){
+                        post = posts.find(p => String(p.slug) === String(slug));
+                    }
                     
                     if (!post){ 
                         showEmpty('Objava ni najdena.'); 
@@ -435,7 +442,8 @@
                     }
                     
                     // Load and convert Markdown content
-                    const markdownRes = await fetch(`/content/news/${encodeURIComponent(post.filename)}`, { cache: 'no-cache' });
+                    const contentPath = post.path || post.link || `/content/news/${post.filename}`;
+                    const markdownRes = await fetch(contentPath, { cache: 'no-cache' });
                     if (!markdownRes.ok){ 
                         showEmpty('Vsebina objave ni na voljo.'); 
                         return; 


### PR DESCRIPTION
Update News page to use `path` for navigation and content fetching, and improve image alt text.

This ensures full compatibility with the new news generator's output, which provides `path` and `imageAlt` fields for more robust linking and accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-46349575-6393-422c-9b3d-eb3229dbdfdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46349575-6393-422c-9b3d-eb3229dbdfdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

