### PR TITLE
Fix news section pin lock functionality

### DIFF
--- a/news/index.html
+++ b/news/index.html
@@ -24,8 +24,8 @@
     </script>
     <link rel="stylesheet" href="/news/news.css">
     <style>
-        .news-lock-overlay { display: none; }
-        .news-locked .news-lock-overlay { display: flex; }
+        .news-lock-overlay { display: none !important; }
+        .news-locked .news-lock-overlay { display: flex !important; }
         .news-locked body > *:not(.news-lock-overlay) { filter: blur(2px); pointer-events: none; user-select: none; }
     </style>
     <script>
@@ -68,6 +68,9 @@
                 console.log('News section locked - PIN required');
             } else {
                 console.log('News section unlocked');
+                // Ensure overlay is hidden when unlocked
+                var overlay = document.querySelector('.news-lock-overlay');
+                if (overlay) overlay.style.display = 'none';
             }
         })();
     </script>
@@ -96,7 +99,7 @@
             <p class="text-gray-600 mb-6">Za ogled novic vnesite PIN za testiranje.</p>
             <form id="news-pin-form" class="flex items-center gap-3" autocomplete="off">
                 <input id="news-pin-input" type="password" inputmode="numeric" pattern="[0-9]*" maxlength="8" placeholder="PIN" class="flex-1 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-orange-500 focus:border-orange-500" />
-                <button type="submit" class="px-4 py-2 rounded-lg bg-orange-600 text-white hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500">Odkljeni</button>
+                <button type="submit" class="px-4 py-2 rounded-lg bg-orange-600 text-white hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500">Odkleni</button>
             </form>
             <p id="news-pin-error" class="mt-3 text-sm text-red-600 hidden" role="alert" aria-live="polite">Napačen PIN. Poskusite znova.</p>
             <div class="mt-4 pt-4 border-t border-gray-200">
@@ -126,6 +129,10 @@
                         }
                         document.documentElement.classList.remove('news-locked');
                         if (error) error.classList.add('hidden');
+                        
+                        // Hide the overlay completely
+                        var overlay = document.querySelector('.news-lock-overlay');
+                        if (overlay) overlay.style.display = 'none';
                         
                         // Clear the input
                         input.value = '';
@@ -173,7 +180,9 @@
                     try {
                         localStorage.removeItem(STORAGE_KEY);
                         console.log('News section locked for testing');
-                        location.reload();
+                        document.documentElement.classList.add('news-locked');
+                        var overlay = document.querySelector('.news-lock-overlay');
+                        if (overlay) overlay.style.display = 'flex';
                     } catch(e){
                         console.warn('Error locking news section:', e);
                     }

--- a/news/post.html
+++ b/news/post.html
@@ -25,8 +25,8 @@
     <link rel="stylesheet" href="/news/news.css">
     <script src="/news/markdown.js"></script>
     <style>
-        .news-lock-overlay { display: none; }
-        .news-locked .news-lock-overlay { display: flex; }
+        .news-lock-overlay { display: none !important; }
+        .news-locked .news-lock-overlay { display: flex !important; }
         .news-locked body > *:not(.news-lock-overlay) { filter: blur(2px); pointer-events: none; user-select: none; }
     </style>
     <script>
@@ -69,6 +69,9 @@
                 console.log('News section locked - PIN required');
             } else {
                 console.log('News section unlocked');
+                // Ensure overlay is hidden when unlocked
+                var overlay = document.querySelector('.news-lock-overlay');
+                if (overlay) overlay.style.display = 'none';
             }
         })();
     </script>
@@ -97,7 +100,7 @@
             <p class="text-gray-600 mb-6">Za ogled vsebine vnesite PIN za testiranje.</p>
             <form id="news-pin-form" class="flex items-center gap-3" autocomplete="off">
                 <input id="news-pin-input" type="password" inputmode="numeric" pattern="[0-9]*" maxlength="8" placeholder="PIN" class="flex-1 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-orange-500 focus:border-orange-500" />
-                <button type="submit" class="px-4 py-2 rounded-lg bg-orange-600 text-white hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500">Odkljeni</button>
+                <button type="submit" class="px-4 py-2 rounded-lg bg-orange-600 text-white hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500">Odkleni</button>
             </form>
             <p id="news-pin-error" class="mt-3 text-sm text-red-600 hidden" role="alert" aria-live="polite">Napačen PIN. Poskusite znova.</p>
             <div class="mt-4 pt-4 border-t border-gray-200">
@@ -127,6 +130,10 @@
                         }
                         document.documentElement.classList.remove('news-locked');
                         if (error) error.classList.add('hidden');
+                        
+                        // Hide the overlay completely
+                        var overlay = document.querySelector('.news-lock-overlay');
+                        if (overlay) overlay.style.display = 'none';
                         
                         // Clear the input
                         input.value = '';
@@ -174,7 +181,9 @@
                     try {
                         localStorage.removeItem(STORAGE_KEY);
                         console.log('News section locked for testing');
-                        location.reload();
+                        document.documentElement.classList.add('news-locked');
+                        var overlay = document.querySelector('.news-lock-overlay');
+                        if (overlay) overlay.style.display = 'flex';
                     } catch(e){
                         console.warn('Error locking news section:', e);
                     }


### PR DESCRIPTION
Fix NEWS section PIN lock to correctly unlock the page and update button text.

The previous PIN unlock logic only removed a CSS class but didn't explicitly hide the overlay, causing the page to remain blurred and inaccessible despite a correct PIN. This PR ensures the overlay is properly hidden on successful unlock and correctly shown on lock.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6e71047-d17d-49ce-b8d3-676e1838214e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6e71047-d17d-49ce-b8d3-676e1838214e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

