### PR TITLE
Add back to main site button to pin ui

### DIFF
--- a/news/index.html
+++ b/news/index.html
@@ -105,6 +105,14 @@
             <div class="mt-4 pt-4 border-t border-gray-200">
                 <button id="lock-news-btn" type="button" class="text-xs text-gray-400 hover:text-gray-600 underline">Zakleni za testiranje</button>
             </div>
+            <div class="mt-6">
+                <a href="/" class="inline-flex items-center justify-center gap-3 w-full px-6 py-4 rounded-xl bg-gray-100 hover:bg-gray-200 text-gray-700 font-semibold text-lg transition-all duration-200 hover:shadow-lg">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path>
+                    </svg>
+                    Nazaj na glavno stran
+                </a>
+            </div>
         </div>
     </div>
     <script>

--- a/news/post.html
+++ b/news/post.html
@@ -106,6 +106,14 @@
             <div class="mt-4 pt-4 border-t border-gray-200">
                 <button id="lock-news-btn" type="button" class="text-xs text-gray-400 hover:text-gray-600 underline">Zakleni za testiranje</button>
             </div>
+            <div class="mt-6">
+                <a href="/" class="inline-flex items-center justify-center gap-3 w-full px-6 py-4 rounded-xl bg-gray-100 hover:bg-gray-200 text-gray-700 font-semibold text-lg transition-all duration-200 hover:shadow-lg">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path>
+                    </svg>
+                    Nazaj na glavno stran
+                </a>
+            </div>
         </div>
     </div>
     <script>


### PR DESCRIPTION
Add a "Back to Main Site" button to the news site's PIN lock UI to provide an easy way for users to return to the main site.

---
<a href="https://cursor.com/background-agent?bcId=bc-89da1589-15e5-462b-8d21-0a71618e5351">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89da1589-15e5-462b-8d21-0a71618e5351">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

