### PR TITLE
Add website favicon from logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
+    <link rel="icon" href="/images/soncelogo.jpg" type="image/jpeg">
     <link rel="manifest" href="/favicons/site.webmanifest">
     <meta name="theme-color" content="#FF5F15">
     <meta name="msapplication-TileColor" content="#FF5F15">
@@ -45,7 +46,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="format-detection" content="telephone=no">
     <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#FF5F15">
-    <link rel="shortcut icon" href="/favicons/favicon.ico">
+    <link rel="shortcut icon" href="/images/soncelogo.jpg" type="image/jpeg">
     <meta name="apple-mobile-web-app-title" content="Sindikat Sonce Koper">
     <meta name="application-name" content="Sindikat Sonce Koper">
     <link rel="apple-touch-startup-image" href="/favicons/apple-splash-2048-2732.png" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">


### PR DESCRIPTION
Add `images/soncelogo.jpg` as the favicon to display the logo in browser tabs.

---
<a href="https://cursor.com/background-agent?bcId=bc-96f53dd1-03dd-4cd9-941e-8a49421b86fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96f53dd1-03dd-4cd9-941e-8a49421b86fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

