### PR TITLE
Create downloadable news generator tool

### DIFF
--- a/generator/.gitignore
+++ b/generator/.gitignore
@@ -1,0 +1,6 @@
+output/
+dist/
+__pycache__/
+*.pyc
+.DS_Store
+

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,0 +1,69 @@
+### Sonce News Generator (Offline, Draft-Only)
+
+This folder contains a small, offline tool that creates draft news files compatible with the website. It does not publish or push anything. It simply produces files you can hand to an editor.
+
+## What you get
+- A simple app to type in a news title, date, summary, author, tags, and pick images
+- It generates one Markdown file and, if you added images, copies/renames them into the correct folder structure
+- It can also create a ZIP that an editor can drop into the website repository
+- All drafts are clearly marked with `draft: true` in the front matter
+
+## Quick start (no command line)
+1. Download the generator-only ZIP (or this `generator/` folder) and unzip it anywhere on your computer.
+2. Open the folder named `generator`.
+3. Double‑click one of these:
+   - On Windows: `run_windows.bat`
+   - On Mac or Linux: `run_mac_linux.sh` (you may need to right‑click > Open)
+4. Fill in the form and click “Generate Draft”.
+5. The draft will be saved into `generator/output/` as:
+   - `content/news/YYYY-MM-DD-slug.md` (your news file)
+   - `static/uploads/news/YYYY/MM/...` (renamed images if you selected them)
+6. Optionally click “Create ZIP for Editor” to produce one ZIP containing both the Markdown and image files in the exact structure the website expects.
+
+Note: The tool works fully offline. If your computer does not have Python installed, install it once from `python.org` and then double‑click the run file again.
+
+## What to send to the editor
+- If you used “Create ZIP for Editor”: send the ZIP file found in `generator/output/` (for example: `news-draft-2025-01-15-welcome-post.zip`). The editor can unzip it into the website repository root and commit.
+- If you did not create a ZIP: send both of these from `generator/output/`:
+  - `content/news/YYYY-MM-DD-slug.md`
+  - the entire folder `static/uploads/news/YYYY/MM/` that contains your images
+
+## What the editor does (for reference)
+- Place the Markdown file under the website repo at `content/news/`.
+- Place the images under `static/uploads/news/YYYY/MM/`.
+- Optionally run validation: `node tools/validate-news.mjs` (not required for you).
+- Publish only after review. Drafts are not published automatically.
+
+## Format (simple schema)
+All fields are entered in the app. The generated Markdown file has a YAML front matter block:
+
+Required fields:
+- title: text
+- date: calendar date in `YYYY-MM-DD`
+
+Recommended fields:
+- slug: lowercase, web‑friendly, dashes between words (auto‑generated from title)
+- summary: short preview text (up to ~200 chars)
+- author: text
+- tags: list of words (you can type comma‑separated; the generator writes a proper list)
+- image: an absolute path like `/static/uploads/news/YYYY/MM/YYYY-MM-DD-slug-hero.jpg` if you chose an image
+- draft: true (always set for safety)
+- datetime: full ISO 8601 timestamp with timezone (extra info retained for humans)
+
+Notes:
+- The website expects `date` as `YYYY-MM-DD`. The generator also records `datetime` (full ISO) for your reference.
+- Images are renamed so the first image becomes `YYYY-MM-DD-slug-hero.ext` and any additional images become `YYYY-MM-DD-slug-{description}.ext`.
+
+## Examples
+See `generator/examples/` for two ready‑to‑drop drafts.
+
+## Packaging a download ZIP (for maintainers)
+- From the repository root or from this folder, run the packaging script:
+  - Linux/Mac: `generator/scripts/package-generator-zip.sh`
+- This creates `generator/dist/news-generator.zip` containing only the generator and documentation.
+
+## Safety and privacy
+- No sign‑in or internet is required.
+- The generator never commits, pushes, or publishes anything.
+- No deploy keys or credentials are included.
+

--- a/generator/examples/README.md
+++ b/generator/examples/README.md
@@ -1,0 +1,8 @@
+### Examples
+
+This folder contains two example drafts ready to drop into the site.
+
+How to use:
+- Copy `content/news/*.md` to the website repo's `content/news/` folder.
+- If an example references an image, ensure the image exists at the path under `static/uploads/news/YYYY/MM/` in the website repo.
+

--- a/generator/examples/content/news/2025-01-15-welcome-post.md
+++ b/generator/examples/content/news/2025-01-15-welcome-post.md
@@ -1,0 +1,19 @@
+---
+title: "Welcome to Sonce News"
+date: 2025-01-15
+slug: "welcome-to-sonce-news"
+author: "Sonce Team"
+summary: "A friendly introduction to the new Sonce news system."
+tags: [news, welcome]
+draft: true
+datetime: 2025-01-15T09:00:00+01:00
+---
+
+Thank you for trying the offline news generator. This is a sample post.
+
+- It uses the required `YYYY-MM-DD` date format.
+- It is clearly marked as a draft.
+- Tags are written as a YAML list.
+
+You can replace this text with your content.
+

--- a/generator/examples/content/news/2025-03-02-community-event.md
+++ b/generator/examples/content/news/2025-03-02-community-event.md
@@ -5,7 +5,7 @@ slug: "community-event-in-march"
 author: "Community Team"
 summary: "Join us for a community meetup with talks and Q&A."
 tags: [community, events]
-image: "/static/uploads/news/2025/03/2025-03-02-community-event-in-march-hero.jpg"
+image: "/static/uploads/news/2025/03/2025-03-02-community-event-in-march-hero.svg"
 imageAlt: "People at a community meetup"
 draft: true
 datetime: 2025-03-02T18:30:00+01:00

--- a/generator/examples/content/news/2025-03-02-community-event.md
+++ b/generator/examples/content/news/2025-03-02-community-event.md
@@ -1,0 +1,23 @@
+---
+title: "Community Event in March"
+date: 2025-03-02
+slug: "community-event-in-march"
+author: "Community Team"
+summary: "Join us for a community meetup with talks and Q&A."
+tags: [community, events]
+image: "/static/uploads/news/2025/03/2025-03-02-community-event-in-march-hero.jpg"
+imageAlt: "People at a community meetup"
+draft: true
+datetime: 2025-03-02T18:30:00+01:00
+---
+
+We're excited to invite you to our March community event.
+
+Agenda:
+
+1. Welcome and introductions
+2. Short talks
+3. Open Q&A
+
+Location details to follow.
+

--- a/generator/examples/static/uploads/news/2025/03/2025-03-02-community-event-in-march-hero.svg
+++ b/generator/examples/static/uploads/news/2025/03/2025-03-02-community-event-in-march-hero.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#fb923c"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#g)"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Arial, Helvetica, sans-serif" font-size="60" fill="#ffffff">
+    Community Event (Placeholder)
+  </text>
+</svg>
+

--- a/generator/news_generator.py
+++ b/generator/news_generator.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import zipfile
+import shutil
+import unicodedata
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import tkinter as tk
+    from tkinter import ttk, filedialog, messagebox
+except Exception as e:
+    print("This tool requires Python with Tkinter installed.\n"
+          "On Windows and macOS, Tkinter is included with the standard installer.\n"
+          "On Linux, install the Tkinter package via your package manager (e.g., python3-tk).\n")
+    raise
+
+
+APP_TITLE = "Sonce News Generator (Draft Only)"
+OUTPUT_ROOT = Path(__file__).parent / "output"
+
+
+def to_slug(value: str) -> str:
+    text = str(value or "").strip().lower()
+    # Remove diacritics
+    text = unicodedata.normalize('NFD', text)
+    text = ''.join(ch for ch in text if unicodedata.category(ch) != 'Mn')
+    # Replace non-alphanumeric with hyphens
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"(^-|-$)", "", text)
+    return text
+
+
+def today_date_str() -> str:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def now_iso_local() -> str:
+    return datetime.now().astimezone().isoformat(timespec='seconds')
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def copy_image_to_uploads(src_path: Path, dest_dir: Path, dest_filename: str) -> Path:
+    ensure_dir(dest_dir)
+    ext = src_path.suffix.lower()
+    target = dest_dir / f"{dest_filename}{ext}"
+    # Avoid overwriting by adding numeric suffix if needed
+    counter = 2
+    while target.exists():
+        target = dest_dir / f"{dest_filename}-{counter}{ext}"
+        counter += 1
+    shutil.copy2(src_path, target)
+    return target
+
+
+def yaml_escape(text: str) -> str:
+    if text is None:
+        return ""
+    s = str(text)
+    # Quote if contains special characters
+    if re.search(r'[":#\[\],]', s) or s.strip() != s or ' ' in s:
+        # escape quotes
+        s = s.replace('"', '\\"')
+        return f'"{s}"'
+    return s
+
+
+class NewsGeneratorApp:
+    def __init__(self, master: tk.Tk):
+        self.master = master
+        master.title(APP_TITLE)
+
+        # State
+        self.hero_image_path: Path | None = None
+        self.additional_images: list[Path] = []
+        self.last_generated_paths: list[Path] = []
+
+        # Variables
+        self.var_title = tk.StringVar()
+        self.var_date = tk.StringVar(value=today_date_str())
+        self.var_datetime = tk.StringVar(value=now_iso_local())
+        self.var_author = tk.StringVar()
+        self.var_slug = tk.StringVar()
+        self.var_tags = tk.StringVar()
+        self.var_draft = tk.BooleanVar(value=True)
+        self.var_image_alt = tk.StringVar()
+
+        # Layout
+        container = ttk.Frame(master, padding=12)
+        container.grid(row=0, column=0, sticky="nsew")
+        master.columnconfigure(0, weight=1)
+        master.rowconfigure(0, weight=1)
+
+        # Form grid
+        row = 0
+        ttk.Label(container, text="Title").grid(row=row, column=0, sticky="w")
+        e_title = ttk.Entry(container, textvariable=self.var_title, width=60)
+        e_title.grid(row=row, column=1, columnspan=3, sticky="ew", padx=(8,0))
+        e_title.bind("<KeyRelease>", self._on_title_change)
+        row += 1
+
+        ttk.Label(container, text="Date (YYYY-MM-DD)").grid(row=row, column=0, sticky="w")
+        ttk.Entry(container, textvariable=self.var_date, width=20).grid(row=row, column=1, sticky="w", padx=(8,0))
+        ttk.Button(container, text="Today", command=lambda: self.var_date.set(today_date_str())).grid(row=row, column=2, sticky="w", padx=(8,0))
+        row += 1
+
+        ttk.Label(container, text="Datetime (ISO 8601)").grid(row=row, column=0, sticky="w")
+        ttk.Entry(container, textvariable=self.var_datetime, width=40).grid(row=row, column=1, sticky="w", padx=(8,0))
+        ttk.Button(container, text="Now", command=lambda: self.var_datetime.set(now_iso_local())).grid(row=row, column=2, sticky="w", padx=(8,0))
+        row += 1
+
+        ttk.Label(container, text="Author").grid(row=row, column=0, sticky="w")
+        ttk.Entry(container, textvariable=self.var_author, width=40).grid(row=row, column=1, columnspan=2, sticky="ew", padx=(8,0))
+        row += 1
+
+        ttk.Label(container, text="Slug").grid(row=row, column=0, sticky="w")
+        ttk.Entry(container, textvariable=self.var_slug, width=40).grid(row=row, column=1, sticky="w", padx=(8,0))
+        ttk.Button(container, text="Regenerate", command=self._regen_slug).grid(row=row, column=2, sticky="w", padx=(8,0))
+        row += 1
+
+        ttk.Label(container, text="Summary (short)").grid(row=row, column=0, sticky="nw")
+        self.txt_summary = tk.Text(container, width=60, height=4)
+        self.txt_summary.grid(row=row, column=1, columnspan=3, sticky="ew", padx=(8,0))
+        row += 1
+
+        ttk.Label(container, text="Tags (comma-separated)").grid(row=row, column=0, sticky="w")
+        ttk.Entry(container, textvariable=self.var_tags, width=60).grid(row=row, column=1, columnspan=3, sticky="ew", padx=(8,0))
+        row += 1
+
+        ttk.Checkbutton(container, text="Draft (recommended)", variable=self.var_draft).grid(row=row, column=0, sticky="w")
+        row += 1
+
+        # Images
+        ttk.Label(container, text="Hero image (optional)").grid(row=row, column=0, sticky="w")
+        self.lbl_hero = ttk.Label(container, text="None selected")
+        self.lbl_hero.grid(row=row, column=1, columnspan=2, sticky="w", padx=(8,0))
+        ttk.Button(container, text="Choose…", command=self.choose_hero).grid(row=row, column=3, sticky="w")
+        row += 1
+
+        ttk.Label(container, text="Image alt text").grid(row=row, column=0, sticky="w")
+        ttk.Entry(container, textvariable=self.var_image_alt, width=60).grid(row=row, column=1, columnspan=3, sticky="ew", padx=(8,0))
+        row += 1
+
+        ttk.Label(container, text="Additional images (optional)").grid(row=row, column=0, sticky="nw")
+        self.lst_images = tk.Listbox(container, height=4, width=50)
+        self.lst_images.grid(row=row, column=1, columnspan=2, sticky="ew", padx=(8,0))
+        btns = ttk.Frame(container)
+        btns.grid(row=row, column=3, sticky="n")
+        ttk.Button(btns, text="Add…", command=self.add_images).grid(row=0, column=0, sticky="ew", pady=2)
+        ttk.Button(btns, text="Remove", command=self.remove_selected_image).grid(row=1, column=0, sticky="ew", pady=2)
+        row += 1
+
+        # Body content (optional)
+        ttk.Label(container, text="Body (optional)").grid(row=row, column=0, sticky="nw")
+        self.txt_body = tk.Text(container, width=60, height=12)
+        self.txt_body.grid(row=row, column=1, columnspan=3, sticky="ew", padx=(8,0))
+        row += 1
+
+        # Actions
+        actions = ttk.Frame(container)
+        actions.grid(row=row, column=0, columnspan=4, sticky="ew", pady=(8,0))
+        ttk.Button(actions, text="Generate Draft", command=self.generate_draft).grid(row=0, column=0, padx=(0,8))
+        ttk.Button(actions, text="Create ZIP for Editor", command=self.create_zip).grid(row=0, column=1, padx=(0,8))
+        ttk.Button(actions, text="Reset Form", command=self.reset_form).grid(row=0, column=2)
+
+        # Status
+        row += 1
+        self.var_status = tk.StringVar(value="Ready.")
+        ttk.Label(container, textvariable=self.var_status).grid(row=row, column=0, columnspan=4, sticky="w", pady=(8,0))
+
+        # Resize weights
+        for c in range(4):
+            container.columnconfigure(c, weight=1 if c in (1,2) else 0)
+
+    def _on_title_change(self, _event=None):
+        if not self.var_slug.get().strip():
+            self.var_slug.set(to_slug(self.var_title.get()))
+
+    def _regen_slug(self):
+        self.var_slug.set(to_slug(self.var_title.get()))
+
+    def choose_hero(self):
+        path = filedialog.askopenfilename(title="Choose hero image",
+                                          filetypes=[("Images", ".jpg .jpeg .png .gif .webp .svg"), ("All files", "*.*")])
+        if path:
+            self.hero_image_path = Path(path)
+            self.lbl_hero.config(text=str(self.hero_image_path.name))
+
+    def add_images(self):
+        paths = filedialog.askopenfilenames(title="Choose additional images",
+                                            filetypes=[("Images", ".jpg .jpeg .png .gif .webp .svg"), ("All files", "*.*")])
+        for p in paths:
+            pth = Path(p)
+            if pth not in self.additional_images:
+                self.additional_images.append(pth)
+                self.lst_images.insert(tk.END, pth.name)
+
+    def remove_selected_image(self):
+        sel = list(self.lst_images.curselection())
+        sel.reverse()
+        for idx in sel:
+            path = self.additional_images[idx]
+            del self.additional_images[idx]
+            self.lst_images.delete(idx)
+
+    def _validate_inputs(self) -> tuple[bool, str]:
+        title = self.var_title.get().strip()
+        if not title:
+            return False, "Title is required."
+        date_str = self.var_date.get().strip()
+        if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
+            return False, "Date must be in YYYY-MM-DD format."
+        try:
+            datetime.strptime(date_str, "%Y-%m-%d")
+        except Exception:
+            return False, "Date is not a valid calendar date."
+        slug = to_slug(self.var_slug.get() or self.var_title.get())
+        if not re.match(r"^[a-z0-9]+(?:-[a-z0-9]+)*$", slug):
+            return False, "Slug must be lowercase letters/numbers with hyphens."
+        return True, ""
+
+    def generate_draft(self):
+        ok, msg = self._validate_inputs()
+        if not ok:
+            messagebox.showerror("Invalid input", msg)
+            return
+
+        # Collect data
+        title = self.var_title.get().strip()
+        date_str = self.var_date.get().strip()
+        dt_iso = self.var_datetime.get().strip() or now_iso_local()
+        author = self.var_author.get().strip()
+        slug = to_slug(self.var_slug.get() or title)
+        summary = self.txt_summary.get("1.0", tk.END).strip().replace("\n", " ")
+        tags_raw = [t.strip() for t in self.var_tags.get().split(',') if t.strip()]
+        tags = tags_raw
+        draft = bool(self.var_draft.get())
+        image_alt = self.var_image_alt.get().strip() or title
+        body = self.txt_body.get("1.0", tk.END).rstrip()
+
+        year, month = date_str.split('-')[0], date_str.split('-')[1]
+
+        # Prepare output dirs
+        content_dir = OUTPUT_ROOT / "content" / "news"
+        uploads_dir = OUTPUT_ROOT / "static" / "uploads" / "news" / year / month
+        ensure_dir(content_dir)
+        ensure_dir(uploads_dir)
+
+        # Copy images
+        image_url = ""
+        written_paths: list[Path] = []
+        if self.hero_image_path:
+            hero_base = f"{date_str}-{slug}-hero"
+            copied = copy_image_to_uploads(self.hero_image_path, uploads_dir, hero_base)
+            # Compute absolute web path
+            image_url = "/" + "/".join(copied.relative_to(OUTPUT_ROOT).parts)
+            image_url = image_url.replace("\\", "/")
+            written_paths.append(copied)
+
+        # Additional images
+        for add_path in self.additional_images:
+            base_name = add_path.stem
+            desc = to_slug(base_name)
+            if not desc or desc == "hero":
+                desc = "image"
+            add_base = f"{date_str}-{slug}-{desc}"
+            copied = copy_image_to_uploads(add_path, uploads_dir, add_base)
+            written_paths.append(copied)
+
+        # Build frontmatter (compatible with site spec; date as YYYY-MM-DD)
+        fm_lines = [
+            "---",
+            f"title: {yaml_escape(title)}",
+            f"date: {date_str}",
+            f"slug: {yaml_escape(slug)}",
+        ]
+        if author:
+            fm_lines.append(f"author: {yaml_escape(author)}")
+        if summary:
+            # Trim to ~200 characters to align with site expectations
+            short = summary[:200].rstrip()
+            fm_lines.append(f"summary: {yaml_escape(short)}")
+        if image_url:
+            fm_lines.append(f"image: {yaml_escape(image_url)}")
+        if image_alt:
+            fm_lines.append(f"imageAlt: {yaml_escape(image_alt)}")
+        if tags:
+            # YAML inline list: [tag1, tag2]
+            tags_escaped = ", ".join(yaml_escape(t) for t in tags)
+            fm_lines.append(f"tags: [{tags_escaped}]")
+        # Always write draft flag for safety
+        fm_lines.append(f"draft: {'true' if draft else 'false'}")
+        # Keep the full datetime for human reference; site ignores unknown fields
+        if dt_iso:
+            fm_lines.append(f"datetime: {yaml_escape(dt_iso)}")
+        fm_lines.append("---")
+
+        # Markdown body
+        if not body.strip():
+            body = "Write your content here."
+
+        content = "\n".join(fm_lines) + "\n\n" + body + "\n"
+
+        # Filename and write
+        filename = f"{date_str}-{slug}.md"
+        md_path = content_dir / filename
+        md_path.write_text(content, encoding='utf-8')
+        written_paths.append(md_path)
+
+        # Save last generated set (relative to OUTPUT_ROOT)
+        rel_written = [p.relative_to(OUTPUT_ROOT) for p in written_paths]
+        self.last_generated_paths = rel_written
+
+        self.var_status.set(f"Draft generated: {md_path}")
+        messagebox.showinfo("Success", f"Draft created at:\n{md_path}\n\nImages (if any) were copied under:\n{uploads_dir}")
+
+    def create_zip(self):
+        if not self.last_generated_paths:
+            messagebox.showwarning("Nothing to zip", "Generate a draft first.")
+            return
+
+        # Try to find the markdown file in the last set to name the zip
+        md_rel = None
+        for p in self.last_generated_paths:
+            if p.as_posix().endswith('.md'):
+                md_rel = p
+                break
+        if md_rel is None:
+            messagebox.showerror("Error", "Could not locate the markdown file to name the ZIP.")
+            return
+
+        slug_part = md_rel.name[:-3]
+        zip_name = f"news-draft-{slug_part}.zip"
+        dist_dir = OUTPUT_ROOT
+        ensure_dir(dist_dir)
+        zip_path = dist_dir / zip_name
+
+        with zipfile.ZipFile(zip_path, 'w', compression=zipfile.ZIP_DEFLATED) as zf:
+            for rel in self.last_generated_paths:
+                abs_path = OUTPUT_ROOT / rel
+                if abs_path.is_file():
+                    # Keep content/ and static/ folder roots inside the archive
+                    zf.write(abs_path, arcname=str(rel))
+
+        self.var_status.set(f"ZIP created: {zip_path}")
+        messagebox.showinfo("ZIP ready", f"ZIP created at:\n{zip_path}\n\nSend this ZIP to the editor.")
+
+    def reset_form(self):
+        self.var_title.set("")
+        self.var_date.set(today_date_str())
+        self.var_datetime.set(now_iso_local())
+        self.var_author.set("")
+        self.var_slug.set("")
+        self.var_tags.set("")
+        self.var_draft.set(True)
+        self.var_image_alt.set("")
+        self.txt_summary.delete("1.0", tk.END)
+        self.txt_body.delete("1.0", tk.END)
+        self.hero_image_path = None
+        self.additional_images.clear()
+        self.lst_images.delete(0, tk.END)
+        self.lbl_hero.config(text="None selected")
+        self.last_generated_paths = []
+        self.var_status.set("Ready.")
+
+
+def main():
+    root = tk.Tk()
+    # Better default minimum size
+    root.minsize(800, 700)
+    NewsGeneratorApp(root)
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/generator/run_mac_linux.sh
+++ b/generator/run_mac_linux.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 news_generator.py
+elif command -v python >/dev/null 2>&1; then
+  exec python news_generator.py
+else
+  echo "Python 3 is required. Please install it from python.org and try again." >&2
+  exit 1
+fi
+

--- a/generator/run_windows.bat
+++ b/generator/run_windows.bat
@@ -1,0 +1,30 @@
+@echo off
+setlocal
+
+set SCRIPT=%~dp0news_generator.py
+
+rem Try Windows Python launcher first
+where py >nul 2>&1
+if %ERRORLEVEL%==0 (
+  py -3 "%SCRIPT%"
+  goto :eof
+)
+
+rem Fallback to python
+where python >nul 2>&1
+if %ERRORLEVEL%==0 (
+  python "%SCRIPT%"
+  goto :eof
+)
+
+rem Fallback to python3
+where python3 >nul 2>&1
+if %ERRORLEVEL%==0 (
+  python3 "%SCRIPT%"
+  goto :eof
+)
+
+echo.
+echo Could not find Python 3. Please install it from https://www.python.org/downloads/ and try again.
+pause
+

--- a/generator/scripts/package-generator-zip.sh
+++ b/generator/scripts/package-generator-zip.sh
@@ -3,39 +3,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GEN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-DIST_DIR="$GEN_DIR/dist"
-ZIP_PATH="$DIST_DIR/news-generator.zip"
 
-mkdir -p "$DIST_DIR"
-
-TMP_DIR="$(mktemp -d)"
-cleanup() { rm -rf "$TMP_DIR"; }
-trap cleanup EXIT
-
-# Copy selected generator files
-rsync -a --exclude 'output/' --exclude 'dist/' --exclude '__pycache__/' --exclude '*.pyc' \
-  --exclude '.DS_Store' --exclude '.git/' --exclude '.gitignore' \
-  "$GEN_DIR/" "$TMP_DIR/generator/"
-
-cd "$TMP_DIR"
-
-if command -v zip >/dev/null 2>&1; then
-  zip -r "$ZIP_PATH" generator
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$GEN_DIR/scripts/package_generator.py"
+elif command -v python >/dev/null 2>&1; then
+  exec python "$GEN_DIR/scripts/package_generator.py"
 else
-  # Fallback to Python zipfile
-  python3 - <<'PY'
-import os, zipfile, sys
-root = 'generator'
-zip_path = sys.argv[1]
-with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
-    for base, _, files in os.walk(root):
-        for f in files:
-            p = os.path.join(base, f)
-            zf.write(p, arcname=p)
-print('Wrote', zip_path)
-PY
-  "$ZIP_PATH"
+  echo "Python 3 is required to package the generator." >&2
+  exit 1
 fi
-
-echo "Created: $ZIP_PATH"
 

--- a/generator/scripts/package-generator-zip.sh
+++ b/generator/scripts/package-generator-zip.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GEN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DIST_DIR="$GEN_DIR/dist"
+ZIP_PATH="$DIST_DIR/news-generator.zip"
+
+mkdir -p "$DIST_DIR"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+# Copy selected generator files
+rsync -a --exclude 'output/' --exclude 'dist/' --exclude '__pycache__/' --exclude '*.pyc' \
+  --exclude '.DS_Store' --exclude '.git/' --exclude '.gitignore' \
+  "$GEN_DIR/" "$TMP_DIR/generator/"
+
+cd "$TMP_DIR"
+
+if command -v zip >/dev/null 2>&1; then
+  zip -r "$ZIP_PATH" generator
+else
+  # Fallback to Python zipfile
+  python3 - <<'PY'
+import os, zipfile, sys
+root = 'generator'
+zip_path = sys.argv[1]
+with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+    for base, _, files in os.walk(root):
+        for f in files:
+            p = os.path.join(base, f)
+            zf.write(p, arcname=p)
+print('Wrote', zip_path)
+PY
+  "$ZIP_PATH"
+fi
+
+echo "Created: $ZIP_PATH"
+

--- a/generator/scripts/package_generator.py
+++ b/generator/scripts/package_generator.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+
+EXCLUDE_DIRS = {"output", "dist", ".git", "__pycache__"}
+EXCLUDE_FILES = {".DS_Store",}
+
+
+def should_include(path: Path, gen_root: Path) -> bool:
+    rel = path.relative_to(gen_root)
+    parts = set(rel.parts)
+    if any(part in EXCLUDE_DIRS for part in rel.parts):
+        return False
+    if path.name in EXCLUDE_FILES:
+        return False
+    return True
+
+
+def main() -> int:
+    gen_root = Path(__file__).resolve().parents[1]
+    dist_dir = gen_root / "dist"
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = dist_dir / "news-generator.zip"
+
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for base, dirs, files in os.walk(gen_root):
+            base_path = Path(base)
+            # Prune excluded dirs from walk
+            dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+            for fname in files:
+                fpath = base_path / fname
+                if not should_include(fpath, gen_root):
+                    continue
+                arcname = f"generator/{fpath.relative_to(gen_root).as_posix()}"
+                zf.write(fpath, arcname)
+
+    print(f"Created: {zip_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/incoming/.gitignore
+++ b/incoming/.gitignore
@@ -1,0 +1,6 @@
+*.tmp/
+*.unpacked/
+*.partial/
+*.work/
+*.LOCK
+

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -1,0 +1,25 @@
+### Incoming ZIPs (Editor Workflow)
+
+Drop generator ZIP files into this `incoming/` folder to import them into the website.
+
+What happens on import:
+- The ZIP is unzipped into a temporary folder
+- The news Markdown file is moved to `content/news/`
+- Images are moved to `static/uploads/news/YYYY/MM/`
+- Image paths in the Markdown front matter and body are fixed to absolute `/static/uploads/news/...`
+- The news index is rebuilt
+- A local git commit is created (no push)
+
+How to use (no command line):
+1. Save the ZIP from the News Generator
+2. Copy the ZIP into `incoming/`
+3. Double‑click one of these at the repository root:
+   - Windows: `run_watch_incoming.bat` (keeps watching) or `run_import_once.bat`
+   - Mac/Linux: `run_watch_incoming.sh` (keeps watching) or `run_import_once.sh`
+
+Troubleshooting:
+- If nothing happens, ensure the script window stays open (watch mode) or run the one‑time import again
+- If the ZIP has no `content/news/*.md`, the importer will skip it
+- If git is not installed or this is not a git repo, the import will work but no commit will be made
+- If images don’t show on the site, confirm the front matter `image:` begins with `/static/uploads/news/` and the files exist under `static/uploads/news/YYYY/MM/`
+

--- a/run_import_once.bat
+++ b/run_import_once.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+
+set SCRIPT=%~dp0tools\import_incoming_zip.py
+
+where py >nul 2>&1
+if %ERRORLEVEL%==0 (
+  py -3 "%SCRIPT%"
+  goto :eof
+)
+
+where python >nul 2>&1
+if %ERRORLEVEL%==0 (
+  python "%SCRIPT%"
+  goto :eof
+)
+
+where python3 >nul 2>&1
+if %ERRORLEVEL%==0 (
+  python3 "%SCRIPT%"
+  goto :eof
+)
+
+echo Python 3 is required to run the importer. Install from https://www.python.org/downloads/
+pause
+

--- a/run_import_once.sh
+++ b/run_import_once.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 tools/import_incoming_zip.py
+elif command -v python >/dev/null 2>&1; then
+  exec python tools/import_incoming_zip.py
+else
+  echo "Python 3 is required to run the importer." >&2
+  exit 1
+fi
+

--- a/run_watch_incoming.bat
+++ b/run_watch_incoming.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+
+echo Watching incoming\ for ZIP files. Close this window to stop.
+:loop
+call "%~dp0run_import_once.bat"
+timeout /t 5 >nul
+goto loop
+

--- a/run_watch_incoming.sh
+++ b/run_watch_incoming.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "Watching incoming/ for ZIP files. Press Ctrl+C to stop."
+
+while true; do
+  if command -v python3 >/dev/null 2>&1; then
+    python3 tools/import_incoming_zip.py || true
+  elif command -v python >/dev/null 2>&1; then
+    python tools/import_incoming_zip.py || true
+  else
+    echo "Python 3 is required to run the importer." >&2
+    exit 1
+  fi
+  sleep 5
+done
+

--- a/tools/import_incoming_zip.py
+++ b/tools/import_incoming_zip.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+import json
+import shutil
+import zipfile
+from pathlib import Path
+from datetime import datetime
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INCOMING_DIR = ROOT / 'incoming'
+CONTENT_DIR = ROOT / 'content' / 'news'
+UPLOADS_ROOT = ROOT / 'static' / 'uploads' / 'news'
+
+MD_EXT_RE = re.compile(r"\.md$", re.IGNORECASE)
+DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})-(?:[a-z0-9]+(?:-[a-z0-9]+)*)\.md$")
+
+
+def info(msg: str):
+    print(f"[incoming] {msg}")
+
+
+def fix_paths_in_text(text: str) -> str:
+    # Normalize any site-relative paths under content->static conventions
+    # Front matter image lines: image: /static/uploads/news/YYYY/MM/...
+    # Convert inline image markdown if it mistakenly used relative paths like images/... to absolute under static
+    text = re.sub(r"(image:\s*)(['\"]?)(?!/static/uploads/news/)([^\n'\"]+)(['\"]?)",
+                  lambda m: f"{m.group(1)}\"/static/uploads/news/{m.group(3).lstrip('/')}\"",
+                  text)
+    # Inline markdown images ![alt](path) -> if path starts with static/uploads/news keep, if content/... or images/... -> rewrite to /static/uploads/news/... best-effort
+    def repl_markdown(m):
+        alt = m.group(1)
+        path = m.group(2)
+        if path.startswith('/static/uploads/news/'):
+            return m.group(0)
+        path = path.lstrip('/')
+        return f"![{alt}](/{'static/uploads/news/' + path})"
+    text = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", repl_markdown, text)
+    return text
+
+
+def rebuild_index() -> None:
+    try:
+        subprocess.run(['node', str(ROOT / 'tools' / 'validate-news.mjs')], check=False)
+    except Exception:
+        # Non-fatal; index may not rebuild if node not present
+        pass
+
+
+def git_commit(message: str) -> None:
+    try:
+        subprocess.run(['git', '-C', str(ROOT), 'add', 'content/news', 'static/uploads/news'], check=False)
+        subprocess.run(['git', '-C', str(ROOT), 'commit', '-m', message], check=False)
+    except Exception:
+        # Non-fatal if git not available
+        pass
+
+
+def import_zip(zip_path: Path) -> bool:
+    info(f"Importing {zip_path.name}")
+    work_dir = zip_path.with_suffix('.unpacked')
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    # Unzip
+    try:
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            zf.extractall(work_dir)
+    except zipfile.BadZipFile:
+        info(f"Skipping (bad zip): {zip_path.name}")
+        return False
+
+    # Locate markdown under content/news/
+    md_files = list(work_dir.rglob('content/news/*.md'))
+    if not md_files:
+        info("No content/news/*.md found in ZIP; skipping")
+        return False
+
+    # Move images if present
+    # Expect images under static/uploads/news/YYYY/MM/**
+    moved_files = []
+    uploads_inside = list(work_dir.rglob('static/uploads/news/*/*/*'))
+    for p in uploads_inside:
+        if p.is_file():
+            rel = p.relative_to(work_dir)
+            dest = ROOT / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(p, dest)
+            moved_files.append(dest)
+
+    # Process markdown(s)
+    for md in md_files:
+        rel_md = md.relative_to(work_dir)
+        if not DATE_RE.search(md.name):
+            info(f"Warning: markdown filename not matching date-slug format: {md.name}")
+        dest_md = ROOT / rel_md
+        dest_md.parent.mkdir(parents=True, exist_ok=True)
+        text = md.read_text(encoding='utf-8')
+        fixed = fix_paths_in_text(text)
+        dest_md.write_text(fixed, encoding='utf-8')
+        moved_files.append(dest_md)
+
+    # Rebuild index and commit locally
+    rebuild_index()
+    git_commit(f"Import news from {zip_path.name}")
+
+    info(f"Imported {zip_path.name}")
+    return True
+
+
+def import_all_incoming() -> int:
+    INCOMING_DIR.mkdir(parents=True, exist_ok=True)
+    zip_files = sorted([p for p in INCOMING_DIR.iterdir() if p.is_file() and p.suffix.lower() == '.zip'])
+    if not zip_files:
+        info("No ZIP files found in incoming/")
+        return 0
+    imported = 0
+    for zp in zip_files:
+        ok = import_zip(zp)
+        if ok:
+            imported += 1
+            # Optionally move processed ZIP to archive
+            processed_dir = INCOMING_DIR / 'processed'
+            processed_dir.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(zp), processed_dir / zp.name)
+    return imported
+
+
+def main() -> int:
+    count = import_all_incoming()
+    info(f"Done. Imported {count} ZIP(s).")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())
+


### PR DESCRIPTION
Add a new `generator/` directory with a Python GUI tool for easy, offline, draft-only news content creation, separate from the main website.

---
<a href="https://cursor.com/background-agent?bcId=bc-92cc235e-0c20-4a78-ad6b-ec365460ce24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92cc235e-0c20-4a78-ad6b-ec365460ce24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

