### PR TITLE
Fix news section button size inconsistency

### DIFF
--- a/news/news.css
+++ b/news/news.css
@@ -185,6 +185,27 @@
     justify-content: center;
 }
 
+/* Prev/Next nav buttons on post page */
+#prev-next a {
+    min-height: 4.5rem; /* ensure consistent height */
+    border-width: 2px;
+}
+
+#prev-next a:hover {
+    border-color: #f97316;
+}
+
+#prev-next a:focus-visible {
+    outline: 2px solid #f97316;
+    outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+    #prev-next a {
+        min-height: 4rem;
+    }
+}
+
 .pagination-btn:hover { 
     border-color: #f97316; 
     color: #f97316;

--- a/news/post.html
+++ b/news/post.html
@@ -269,7 +269,7 @@
                 <div id="content" class="news-article prose prose-lg max-w-none"></div>
                 <p id="post-empty" class="hidden text-gray-600 text-center py-12">Objava ni najdena.</p>
                 
-                <nav id="prev-next" aria-label="Navigacija med objavami" class="hidden mt-10 grid grid-cols-1 md:grid-cols-2 gap-4"></nav>
+                <nav id="prev-next" aria-label="Navigacija med objavami" class="hidden mt-10 grid grid-cols-1 md:grid-cols-2 gap-4 items-stretch"></nav>
                 <section id="related" class="hidden mt-12">
                     <h2 class="text-xl font-semibold text-gray-900 mb-4">Sorodne objave</h2>
                     <div id="related-list" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"></div>
@@ -469,7 +469,8 @@
                         a.href = (prev.path || prev.link) ? `/news/post.html?path=${encodeURIComponent(prev.path || prev.link)}` : `/news/post.html?slug=${encodeURIComponent(prev.slug)}`;
                         a.rel = 'prev';
                         a.title = (prev.title || '').toString();
-                        a.className = 'group block p-4 border border-gray-200 rounded-xl bg-white hover:border-orange-300 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 transition-colors transition-shadow';
+                        a.setAttribute('aria-label', `Prejšnja objava: ${(prev.title || '').toString()}`);
+                        a.className = 'group block w-full h-full p-4 border border-gray-200 rounded-xl bg-white hover:border-orange-300 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 transition-colors transition-shadow text-left flex flex-col justify-between';
                         a.innerHTML = `<div class="text-xs font-medium tracking-wider text-gray-500 mb-1">← Prejšnja</div><div class="font-semibold text-gray-900 line-clamp-2 group-hover:text-orange-700">${escapeHtml(prev.title||'')}</div>`;
                         els.prevNext.appendChild(a);
                         hasAny = true;
@@ -480,7 +481,8 @@
                         a.href = (next.path || next.link) ? `/news/post.html?path=${encodeURIComponent(next.path || next.link)}` : `/news/post.html?slug=${encodeURIComponent(next.slug)}`;
                         a.rel = 'next';
                         a.title = (next.title || '').toString();
-                        a.className = 'group block p-4 border border-gray-200 rounded-xl bg-white hover:border-orange-300 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 transition-colors transition-shadow md:ml-auto';
+                        a.setAttribute('aria-label', `Naslednja objava: ${(next.title || '').toString()}`);
+                        a.className = 'group block w-full h-full p-4 border border-gray-200 rounded-xl bg-white hover:border-orange-300 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 transition-colors transition-shadow text-left flex flex-col justify-between';
                         a.innerHTML = `<div class="text-xs font-medium tracking-wider text-gray-500 mb-1">Naslednja →</div><div class="font-semibold text-gray-900 line-clamp-2 group-hover:text-orange-700">${escapeHtml(next.title||'')}</div>`;
                         els.prevNext.appendChild(a);
                         hasAny = true;


### PR DESCRIPTION
Standardize the size, layout, and appearance of news post navigation buttons to fix inconsistent sizing and improve accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-fee0eb87-6d6f-481b-82b4-8f4444f23f38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fee0eb87-6d6f-481b-82b4-8f4444f23f38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

