### PR TITLE
Refactor and improve news generator

### DIFF
--- a/generator/run_simple_linux.sh
+++ b/generator/run_simple_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Starting Easy News Maker..."
+echo "Starting Simple News Maker..."
 echo ""
 
 SCRIPT="$(dirname "$0")/news_generator_simple.py"

--- a/generator/run_simple_windows.bat
+++ b/generator/run_simple_windows.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-echo Starting Easy News Maker...
+echo Starting Simple News Maker...
 echo.
 
 set SCRIPT=%~dp0news_generator_simple.py


### PR DESCRIPTION
Rename "Easy Mode" News Maker to "Simple", unify its ZIP naming, and add a "Copy ZIP to incoming…" feature to standardize makers and improve the workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-c303e3de-1444-49fc-bef3-40cbe1023995">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c303e3de-1444-49fc-bef3-40cbe1023995">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

