### PR TITLE
Check news post formatting and colors

### DIFF
--- a/news/markdown.js
+++ b/news/markdown.js
@@ -3,9 +3,9 @@ class MarkdownConverter {
     constructor() {
         this.rules = [
             // Headers
-            { pattern: /^### (.*$)/gim, replacement: '<h3 class="text-xl font-semibold mt-6 mb-3 text-gray-800">$1</h3>' },
-            { pattern: /^## (.*$)/gim, replacement: '<h2 class="text-2xl font-semibold mt-8 mb-4 text-gray-900">$1</h2>' },
-            { pattern: /^# (.*$)/gim, replacement: '<h1 class="text-3xl font-bold mt-8 mb-4 text-gray-900">$1</h1>' },
+            { pattern: /^### (.*$)/gim, replacement: '<h3 class="text-xl font-semibold mt-6 mb-3">$1</h3>' },
+            { pattern: /^## (.*$)/gim, replacement: '<h2 class="text-2xl font-semibold mt-8 mb-4">$1</h2>' },
+            { pattern: /^# (.*$)/gim, replacement: '<h1 class="text-3xl font-bold mt-8 mb-4">$1</h1>' },
             
             // Images (place before links so it doesn't get treated as a link)
             { pattern: /!\[([^\]]*)\]\(([^)]+)\)/g, replacement: '<img src="$2" alt="$1" class="my-4 rounded-lg max-w-full h-auto">' },
@@ -15,31 +15,31 @@ class MarkdownConverter {
             { pattern: /\*(.*?)\*/g, replacement: '<em class="italic">$1</em>' },
             
             // Code blocks
-            { pattern: /```([\s\S]*?)```/g, replacement: '<pre class="bg-gray-100 p-4 rounded-lg overflow-x-auto my-4"><code>$1</code></pre>' },
-            { pattern: /`([^`]+)`/g, replacement: '<code class="bg-gray-100 px-2 py-1 rounded text-sm font-mono">$1</code>' },
+            { pattern: /```([\s\S]*?)```/g, replacement: '<pre><code>$1</code></pre>' },
+            { pattern: /`([^`]+)`/g, replacement: '<code>$1</code>' },
             
             // Links
-            { pattern: /\[([^\]]+)\]\(([^)]+)\)/g, replacement: '<a href="$2" class="text-primary hover:underline">$1</a>' },
+            { pattern: /\[([^\]]+)\]\(([^)]+)\)/g, replacement: '<a href="$2">$1</a>' },
             
             // Blockquotes
-            { pattern: /^>\s?(.*$)/gim, replacement: '<blockquote class="border-l-4 border-gray-200 pl-4 italic text-gray-700 my-4">$1</blockquote>' },
+            { pattern: /^>\s?(.*$)/gim, replacement: '<blockquote>$1</blockquote>' },
 
-            // Lists
-            { pattern: /^\* (.*$)/gim, replacement: '<li class="ml-4">$1</li>' },
-            { pattern: /^- (.*$)/gim, replacement: '<li class="ml-4">$1</li>' },
-            { pattern: /^(\d+)\. (.*$)/gim, replacement: '<li class="ml-4">$2</li>' },
+            // Lists (use temporary flags to allow grouping later)
+            { pattern: /^\* (.*$)/gim, replacement: '<li data-ul="1">$1</li>' },
+            { pattern: /^- (.*$)/gim, replacement: '<li data-ul="1">$1</li>' },
+            { pattern: /^(\d+)\. (.*$)/gim, replacement: '<li data-ol="1">$2</li>' },
             
             // Paragraphs
             { pattern: /^\s*(\n)?(.+)/gm, replacement: function(match) {
-                return match.trim() ? '<p class="mb-4 text-gray-700 leading-relaxed">' + match.trim() + '</p>' : '';
+                return match.trim() ? '<p>' + match.trim() + '</p>' : '';
             }},
             
             // Line breaks
-            { pattern: /\n\n/g, replacement: '</p>\n<p class="mb-4 text-gray-700 leading-relaxed">' },
+            { pattern: /\n\n/g, replacement: '</p>\n<p>' },
             
             // Clean up empty paragraphs
-            { pattern: /<p class="mb-4 text-gray-700 leading-relaxed"><\/p>/g, replacement: '' },
-            { pattern: /<p class="mb-4 text-gray-700 leading-relaxed">\s*<\/p>/g, replacement: '' }
+            { pattern: /<p><\/p>/g, replacement: '' },
+            { pattern: /<p>\s*<\/p>/g, replacement: '' }
         ];
     }
 
@@ -58,8 +58,21 @@ class MarkdownConverter {
         });
         
         // Wrap lists properly
-        html = html.replace(/(<li.*<\/li>)/gs, '<ul class="list-disc mb-4 ml-6">$1</ul>');
-        html = html.replace(/(<li.*<\/li>)/gs, '<ol class="list-decimal mb-4 ml-6">$1</ol>');
+        // Remove paragraph wrappers around list items to avoid invalid markup
+        html = html.replace(/<p>\s*(<li[^>]*>.*?<\/li>)\s*<\/p>/gs, '$1');
+        // Group consecutive unordered list items
+        html = html.replace(/(?:\n|^)((?:<li[^>]*data-ul=\"1\"[^>]*>.*?<\/li>\s*)+)/g, function(_m, list){
+            return '<ul>' + list + '<\/ul>';
+        });
+        // Group consecutive ordered list items
+        html = html.replace(/(?:\n|^)((?:<li[^>]*data-ol=\"1\"[^>]*>.*?<\/li>\s*)+)/g, function(_m, list){
+            return '<ol>' + list + '<\/ol>';
+        });
+        // Remove temporary data flags
+        html = html.replace(/\sdata-ul=\"1\"/g, '');
+        html = html.replace(/\sdata-ol=\"1\"/g, '');
+        // Remove paragraph wrappers around ul/ol that may have been introduced
+        html = html.replace(/<p>\s*((?:<ul|<ol)[\s\S]*?<\/(?:ul|ol)>)\s*<\/p>/g, '$1');
         
         // Clean up multiple list wrappers
         html = html.replace(/<\/ul>\s*<ul[^>]*>/g, '');


### PR DESCRIPTION
Remove conflicting inline Tailwind color classes from the Markdown converter and fix list wrapping to ensure consistent typography.

The Markdown converter was injecting explicit Tailwind text color classes (e.g., `text-gray-700`) directly into the HTML, overriding the unified color palette defined in `news/news.css`. This led to inconsistent text colors on the news post page. This PR removes these conflicting inline classes, allowing page-wide CSS to control typography consistently. It also adjusts list generation to produce valid HTML, preventing styling issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-31717171-3ce4-4f6b-9589-031d6c9ed1e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31717171-3ce4-4f6b-9589-031d6c9ed1e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

