### PR TITLE
Fix small background element on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1202,9 +1202,9 @@
             .bg-white\\/10.backdrop-blur-sm.rounded-xl.p-4.border.border-white\\/10.shadow-2xl.floating {
                 max-width: 100% !important;
                 margin: 2rem auto 0 !important;
-                background: rgba(255, 255, 255, 0.95) !important;
-                border: 2px solid rgba(255, 255, 255, 0.8) !important;
-                box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1) !important;
+                background: rgba(255, 255, 255, 0.1) !important;
+                border: 1px solid rgba(255, 255, 255, 0.2) !important;
+                box-shadow: 0 4px 16px rgba(0, 0, 0, 0.05) !important;
             }
             
             /* Mobile text improvements */


### PR DESCRIPTION
Adjust mobile hero image card styling to remove unwanted dark shade and improve subtlety.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2d2a747-42a0-4207-81cd-45d995ac33a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2d2a747-42a0-4207-81cd-45d995ac33a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

