### PR TITLE
Hide member count and background overlay on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3630,7 +3630,7 @@
                         </a>
                     </div>
                     
-                    <div class="mt-12 flex items-center space-x-6" data-aos="fade-up" data-aos-delay="400">
+                    <div class="mt-12 hidden md:flex items-center space-x-6" data-aos="fade-up" data-aos-delay="400">
                         <div class="flex -space-x-2 hidden">
                             <img data-src="https://randomuser.me/api/portraits/women/32.jpg" class="w-10 h-10 rounded-full border-2 border-white lazy-image" alt="Member" loading="lazy">
                             <img data-src="https://randomuser.me/api/portraits/men/75.jpg" class="w-10 h-10 rounded-full border-2 border-white lazy-image" alt="Member" loading="lazy">
@@ -3649,7 +3649,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="lg:w-1/2" data-aos="fade-left" data-aos-delay="300">
+                <div class="hidden md:block lg:w-1/2" data-aos="fade-left" data-aos-delay="300">
                         <div class="hero-image-card bg-white/10 backdrop-blur-sm rounded-xl p-4 border border-white/10 shadow-2xl floating" style="max-width: 60%; margin: 0 auto;">
                         <img data-src="https://i.imgur.com/vBKRRYp.jpeg" 
                              alt="Pravna pomoč in sindikalna zaščita za zaposlene v Sloveniji" 


### PR DESCRIPTION
Hide the member count text and the right hero image card on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-f26f26df-b368-4e92-8054-cc8133a4abf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f26f26df-b368-4e92-8054-cc8133a4abf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

