### PR TITLE
Create clickable linux news generator

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -13,7 +13,9 @@ This folder contains a tiny offline app that creates draft news files compatible
 2. Open the folder named `generator`.
 3. Double‑click one of these:
    - On Windows: `run_windows.bat`
-   - On Mac or Linux: `run_mac_linux.sh` (you may need to right‑click > Open)
+   - On macOS: `run_mac_linux.sh` (you may need to right‑click > Open)
+   - On Linux (no terminal): double‑click `SonceNewsMakerEasy.desktop` or `SonceNewsMakerAdvanced.desktop`
+     - If your file manager asks to “Mark as executable”, choose Yes. If it opens as text, right‑click the file → Properties → Permissions → check “Allow executing file as program”. Then double‑click again.
 4. Fill in the form and click “Generate Draft”. Tooltips explain each field.
 5. The draft will be saved into `generator/output/` as:
    - `content/news/YYYY-MM-DD-slug.md` (your news file)
@@ -22,6 +24,10 @@ This folder contains a tiny offline app that creates draft news files compatible
 7. Click “Copy ZIP to incoming…” and choose your website folder (or its `incoming/` folder). The file will be copied there.
 
 Note: The tool works fully offline. If your computer does not have Python installed, install it once from `python.org` and then double‑click the run file again.
+
+### Linux dependency notes
+- Requires Python 3 with Tkinter (package `python3-tk` on Debian/Ubuntu; `python3-tkinter` on Fedora; `tk` on Arch).
+- If dependencies are missing, the launcher will show a GUI error dialog with exact install commands.
 
 ## What to send to the editor
 - If you used “Create ZIP”: use the “Copy ZIP to incoming…” button, or send the ZIP file found in `generator/output/` (e.g. `news-draft-2025-01-15-welcome-post.zip`). The editor can copy it into the website repo under `incoming/`.

--- a/generator/SonceNewsMakerAdvanced.desktop
+++ b/generator/SonceNewsMakerAdvanced.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Sonce News Maker (Advanced)
+Comment=Full-featured news generator
+Exec=sh -c 'cd "$(dirname "\"%k\"")" && ./run_mac_linux.sh'
+Terminal=false
+Categories=Utility;
+StartupNotify=true
+Icon=utilities-terminal

--- a/generator/SonceNewsMakerEasy.desktop
+++ b/generator/SonceNewsMakerEasy.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Sonce News Maker (Easy)
+Comment=Create a news ZIP in one click
+Exec=sh -c 'cd "$(dirname "\"%k\"")" && ./run_simple_linux.sh'
+Terminal=false
+Categories=Utility;
+StartupNotify=true
+# Optional icon; desktop environments may ignore relative paths. Adjust if needed.
+Icon=utilities-terminal

--- a/generator/run_mac_linux.sh
+++ b/generator/run_mac_linux.sh
@@ -3,12 +3,43 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+show_gui_error() {
+  local message="$1"
+  if command -v zenity >/dev/null 2>&1; then
+    zenity --error --title="Sonce News Maker (Advanced)" --width=480 --text="$message" || true
+  elif command -v kdialog >/dev/null 2>&1; then
+    kdialog --error "$message" || true
+  elif command -v xmessage >/dev/null 2>&1; then
+    xmessage -center "$message" || true
+  else
+    printf "%s\n" "$message" >&2
+  fi
+}
+
+# Pick Python interpreter
+PYTHON_BIN=""
 if command -v python3 >/dev/null 2>&1; then
-  exec python3 news_generator.py
+  PYTHON_BIN="python3"
 elif command -v python >/dev/null 2>&1; then
-  exec python news_generator.py
+  PYTHON_BIN="python"
 else
-  echo "Python 3 is required. Please install it from python.org and try again." >&2
+  show_gui_error "Python 3 is required.\n\nInstall it and try again.\n\nExamples:\n• Ubuntu/Debian: sudo apt-get install python3 python3-tk\n• Fedora: sudo dnf install python3 python3-tkinter\n• Arch: sudo pacman -S python tk"
   exit 1
 fi
+
+# Verify Tkinter availability before launching GUI
+if ! "$PYTHON_BIN" - <<'PY' >/dev/null 2>&1
+import sys
+try:
+    import tkinter  # noqa: F401
+except Exception:
+    sys.exit(2)
+sys.exit(0)
+PY
+then
+  show_gui_error "Tkinter (python3-tk) is missing for Python 3.\n\nInstall it and try again.\n\nExamples:\n• Ubuntu/Debian: sudo apt-get install python3-tk\n• Fedora: sudo dnf install python3-tkinter\n• Arch: sudo pacman -S tk"
+  exit 1
+fi
+
+exec "$PYTHON_BIN" news_generator.py
 


### PR DESCRIPTION
Add Linux desktop launchers and harden run scripts to enable double-clicking the news generator and provide GUI error messages for missing dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-8dadcfb9-a586-4297-9850-027441978fe2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8dadcfb9-a586-4297-9850-027441978fe2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

